### PR TITLE
Expose used SSL Labs API version

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Query used API version with ssllabs.api.API_VERSION
+
 ## [v0.2.0] - 2021/01/28
 
 ### Added

--- a/ssllabs/api/__init__.py
+++ b/ssllabs/api/__init__.py
@@ -1,7 +1,8 @@
+from ._api import API_VERSION
 from .analyze import Analyze
 from .endpoint import Endpoint
 from .info import Info
 from .root_certs_raw import RootCertsRaw
 from .status_codes import StatusCodes
 
-__all__ = ["Analyze", "Endpoint", "Info", "RootCertsRaw", "StatusCodes"]
+__all__ = ["API_VERSION", "Analyze", "Endpoint", "Info", "RootCertsRaw", "StatusCodes"]


### PR DESCRIPTION
It might be interesting to know which SSL Labs API version is used. 