### PR TITLE
API classes can reuse existing HTTP client

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Query used API version with ssllabs.api.API_VERSION
+- Low level methods now can reuse an existing AsyncClient instance
 
 ## [v0.2.0] - 2021/01/28
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ from logging import Logger
 from unittest.mock import patch
 
 import pytest
-from httpx import HTTPStatusError, Request, Response
+from httpx import AsyncClient, HTTPStatusError, Request, Response
 
 from ssllabs.api._api import _Api
 from ssllabs.api.analyze import Analyze
@@ -77,6 +77,14 @@ class TestApi:
         r = RootCertsRaw()
         root_certs = await r.get()
         assert type(root_certs) is str
+
+    @pytest.mark.asyncio
+    async def test_not_closing_client(self, mocker):
+        api = _Api()
+        api._needs_closing = False  # pylint: disable=protected-access
+        spy = mocker.spy(AsyncClient, "aclose")
+        del api
+        assert spy.call_count == 0
 
     def test_unknown_parameter(self, mocker):
         spy = mocker.spy(Logger, "warning")


### PR DESCRIPTION
Multiple HTTP client might use to many resources. Let's enable reusing an existing client, if wanted.