### PR TITLE
Handle read timeout of API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Query used API version with ssllabs.api.API_VERSION
 - Low level methods now can reuse an existing AsyncClient instance
 
+### Fixed
+
+- Fix dataclasses for certain situations
+
 ## [v0.2.0] - 2021/01/28
 
 ### Added

--- a/ssllabs/api/analyze.py
+++ b/ssllabs/api/analyze.py
@@ -30,6 +30,8 @@ class Analyze(_Api):
         :key ignoreMismatch: Set to "on" to proceed with assessments even when the server certificate doesn't match the
                              assessment hostname. Set to off by default. Please note that this parameter is ignored if a
                              cached report is returned.
+        :raises httpx.ReadTimeout: SSL Labs Servers don't respond.
+        :raises httpx.ConnectTimeout: SSL Labs Servers don't respond.
         """
         self._verify_kwargs(kwargs.keys(), ["publish", "startNew", "fromCache", "maxAge", "all", "ignoreMismatch"])
         r = await self._call("analyze", host=host, **kwargs)

--- a/ssllabs/api/endpoint.py
+++ b/ssllabs/api/endpoint.py
@@ -18,6 +18,8 @@ class Endpoint(_Api):
         :key fromCache: Always deliver cached assessment reports if available; optional, defaults to "off". This parameter is
                         intended for API consumers that don't want to wait for assessment results. Can't be used at the same
                         time as the startNew parameter.
+        :raises httpx.ReadTimeout: SSL Labs Servers don't respond.
+        :raises httpx.ConnectTimeout: SSL Labs Servers don't respond.
         """
         self._verify_kwargs(kwargs.keys(), ["fromCache"])
         r = await self._call("getEndpointData", host=host, s=s, **kwargs)

--- a/ssllabs/api/info.py
+++ b/ssllabs/api/info.py
@@ -11,6 +11,10 @@ class Info(_Api):
     """
 
     async def get(self) -> InfoData:
-        """Get information."""
+        """Get information.
+
+        :raises httpx.ReadTimeout: SSL Labs Servers don't respond.
+        :raises httpx.ConnectTimeout: SSL Labs Servers don't respond.
+        """
         r = await self._call("info")
         return from_dict(data_class=InfoData, data=r.json())

--- a/ssllabs/api/root_certs_raw.py
+++ b/ssllabs/api/root_certs_raw.py
@@ -11,6 +11,8 @@ class RootCertsRaw(_Api):
         """Retrieve root certificates.
 
         :key trustStore: 1-Mozilla(default), 2-Apple MacOS, 3-Android, 4-Java, 5-Windows
+        :raises httpx.ReadTimeout: SSL Labs Servers don't respond.
+        :raises httpx.ConnectTimeout: SSL Labs Servers don't respond.
         """
         self._verify_kwargs(kwargs.keys(), ["trustStore"])
         r = await self._call("getRootCertsRaw", **kwargs)

--- a/ssllabs/api/status_codes.py
+++ b/ssllabs/api/status_codes.py
@@ -11,6 +11,10 @@ class StatusCodes(_Api):
     """
 
     async def get(self) -> StatusCodesData:
-        """Retrieve known status codes."""
+        """Retrieve known status codes.
+
+        :raises httpx.ReadTimeout: SSL Labs Servers don't respond.
+        :raises httpx.ConnectTimeout: SSL Labs Servers don't respond.
+        """
         r = await self._call("getStatusCodes")
         return from_dict(data_class=StatusCodesData, data=r.json())

--- a/ssllabs/data/http_transaction.py
+++ b/ssllabs/data/http_transaction.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 @dataclass
@@ -12,16 +12,16 @@ class HttpTransactionData:
     requestUrl: str
     """Request URL"""
 
-    statusCode: int
+    statusCode: Optional[int]
     """Response status code"""
 
-    requestLine: str
+    requestLine: Optional[str]
     """The entire request line as a single field"""
 
     requestHeaders: List[str]
     """An array of request HTTP headers, each with name and value"""
 
-    responseLine: str
+    responseLine: Optional[str]
     """The entire response line as a single field"""
 
     responseHeadersRaw: List[str]

--- a/ssllabs/data/trust.py
+++ b/ssllabs/data/trust.py
@@ -12,7 +12,7 @@ class TrustData:
     rootStore: str
     """this field shows the Trust store being used (eg. 'Mozilla')"""
 
-    isTrusted: bool
+    isTrusted: Optional[bool]
     """True if trusted against above rootStore"""
 
     trustErrorMessage: Optional[str]

--- a/ssllabs/ssllabs.py
+++ b/ssllabs/ssllabs.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-from httpx import HTTPStatusError
+from httpx import ConnectTimeout, HTTPStatusError, ReadTimeout
 
 from .api import Analyze, Info, RootCertsRaw, StatusCodes
 from .data.host import HostData
@@ -27,7 +27,7 @@ class Ssllabs():
             await i.get()
             self._logger.info("SSL Labs servers are up an running.")
             return True
-        except HTTPStatusError as ex:
+        except (HTTPStatusError, ReadTimeout, ConnectTimeout) as ex:
             self._logger.error(ex)
             return False
 


### PR DESCRIPTION
The API is sometimes not responding at all. This handles this situation a little more graceful.