### PR TITLE
Allow using cached results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.1.0] - 2022/02/16
+## [v1.2.0] - 2023/03/06
+
+### Added
+
+- Allow using cached results
+
+## [v1.1.0] - 2023/02/16
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ async def analyze():
 asyncio.run(analyze())
 ```
 
-This will give you a [Host object](https://github.com/ssllabs/ssllabs-scan/blob/master/ssllabs-api-docs-v3.md#host) as dataclass. This call runs quite long as it takes time to run all tests. You probably know that from using the [webinterface](https://www.ssllabs.com/ssltest). If you don't need a fresh result on every run, you can allow using ssllabs' cache. This will speed up the tests, if there are cached results.
+This will give you a [Host object](https://github.com/ssllabs/ssllabs-scan/blob/master/ssllabs-api-docs-v3.md#host) as dataclass. This call runs quite long as it takes time to run all tests. You probably know that from using the [webinterface](https://www.ssllabs.com/ssltest). If you don't need a fresh result on every run, you can allow using ssllabs' cache. This will speed up the tests, if there are cached results. The maximum cache validity can be set in full hour steps.
 
 ```python
 import asyncio
@@ -68,7 +68,7 @@ from ssllabs import Ssllabs
 
 async def analyze():
     ssllabs = Ssllabs()
-    return await ssllabs.analyze(host="devolo.de", from_cache=True)
+    return await ssllabs.analyze(host="devolo.de", from_cache=True, max_age=1)
 
 asyncio.run(analyze())
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,19 @@ async def analyze():
 asyncio.run(analyze())
 ```
 
-This will give you a [Host object](https://github.com/ssllabs/ssllabs-scan/blob/master/ssllabs-api-docs-v3.md#host) as dataclass. This call runs quite long as it takes time to run all tests. You probably know that from using the [webinterface](https://www.ssllabs.com/ssltest).
+This will give you a [Host object](https://github.com/ssllabs/ssllabs-scan/blob/master/ssllabs-api-docs-v3.md#host) as dataclass. This call runs quite long as it takes time to run all tests. You probably know that from using the [webinterface](https://www.ssllabs.com/ssltest). If you don't need a fresh result on every run, you can allow using ssllabs' cache. This will speed up the tests, if there are cached results.
+
+```python
+import asyncio
+
+from ssllabs import Ssllabs
+
+async def analyze():
+    ssllabs = Ssllabs()
+    return await ssllabs.analyze(host="devolo.de", from_cache=True)
+
+asyncio.run(analyze())
+```
 
 ### Check availability of the SSL Labs servers
 
@@ -75,7 +87,7 @@ async def availability():
 asyncio.run(availability())
 ```
 
-This will give you True, if the servers are up and running, otherwise False. It will also report False, if you exeeded your rate limits.
+This will give you True, if the servers are up and running, otherwise False. It will also report False, if you exceeded your rate limits.
 
 ### Retrieve API information
 
@@ -107,7 +119,7 @@ async def root_certs():
 asyncio.run(root_certs())
 ```
 
-This will give you a string containing the latest root certificates used for trust validation. By default it used the certificates provided by Mozilla. You can choose a differenty store by changing trust_store to 1: Mozilla, 2: Apple MacOS, 3: Android, 4: Java or 5: Windows.
+This will give you a string containing the latest root certificates used for trust validation. By default it used the certificates provided by Mozilla. You can choose a differently store by changing trust_store to 1: Mozilla, 2: Apple MacOS, 3: Android, 4: Java or 5: Windows.
 
 ### Retrieve known status codes
 

--- a/ssllabs/ssllabs.py
+++ b/ssllabs/ssllabs.py
@@ -33,13 +33,16 @@ class Ssllabs:
             self._logger.error(ex)
             return False
 
-    async def analyze(self, host: str, publish: bool = False, ignore_mismatch: bool = False) -> HostData:
+    async def analyze(
+        self, host: str, publish: bool = False, ignore_mismatch: bool = False, from_cache: bool = False
+    ) -> HostData:
         """
         Test a particular host with respect to the cool off and the maximum number of assessments.
 
         :param host: Host to test
         :param publish: True if assessment results should be published on the public results boards
         :param ignore_mismatch: True if assessment shall proceed even when the server certificate doesn't match the hostname
+        :param from_cache: True if cached results should be used instead of new assessments
 
         See also: https://github.com/ssllabs/ssllabs-scan/blob/master/ssllabs-api-docs-v3.md#protocol-usage
         """
@@ -60,7 +63,10 @@ class Ssllabs:
 
         a = Analyze(self._client)
         host_object = await a.get(
-            host=host, startNew="on", publish="on" if publish else "off", ignoreMismatch="on" if ignore_mismatch else "off"
+            host=host,
+            startNew="off" if from_cache else "on",
+            publish="on" if publish else "off",
+            ignoreMismatch="on" if ignore_mismatch else "off",
         )
         self._semaphore.release()
         while host_object.status not in ["READY", "ERROR"]:

--- a/ssllabs/ssllabs.py
+++ b/ssllabs/ssllabs.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from typing import Optional
 
-from httpx import AsyncClient, ConnectTimeout, HTTPStatusError, ReadTimeout
+from httpx import AsyncClient, ConnectTimeout, HTTPStatusError, ReadError, ReadTimeout
 
 from .api import Analyze, Info, RootCertsRaw, StatusCodes
 from .data.host import HostData
@@ -29,12 +29,17 @@ class Ssllabs:
             await i.get()
             self._logger.info("SSL Labs servers are up an running.")
             return True
-        except (HTTPStatusError, ReadTimeout, ConnectTimeout) as ex:
+        except (HTTPStatusError, ReadError, ReadTimeout, ConnectTimeout) as ex:
             self._logger.error(ex)
             return False
 
     async def analyze(
-        self, host: str, publish: bool = False, ignore_mismatch: bool = False, from_cache: bool = False
+        self,
+        host: str,
+        publish: bool = False,
+        ignore_mismatch: bool = False,
+        from_cache: bool = False,
+        max_age: Optional[int] = None,
     ) -> HostData:
         """
         Test a particular host with respect to the cool off and the maximum number of assessments.
@@ -43,6 +48,7 @@ class Ssllabs:
         :param publish: True if assessment results should be published on the public results boards
         :param ignore_mismatch: True if assessment shall proceed even when the server certificate doesn't match the hostname
         :param from_cache: True if cached results should be used instead of new assessments
+        :param max_age: Maximum age cached data might have in hours
 
         See also: https://github.com/ssllabs/ssllabs-scan/blob/master/ssllabs-api-docs-v3.md#protocol-usage
         """
@@ -67,6 +73,7 @@ class Ssllabs:
             startNew="off" if from_cache else "on",
             publish="on" if publish else "off",
             ignoreMismatch="on" if ignore_mismatch else "off",
+            maxAge=max_age,
         )
         self._semaphore.release()
         while host_object.status not in ["READY", "ERROR"]:

--- a/tests/test_ssllabs.py
+++ b/tests/test_ssllabs.py
@@ -43,10 +43,10 @@ class TestSsllabs:
             ssllabs = Ssllabs()
             api_data = await ssllabs.analyze(host="devolo.de")
             assert dataclasses.asdict(api_data) == request.cls.analyze
-            assert get.call_args.kwargs["startNew"] == "on"
+            get.assert_called_with(host="devolo.de", ignoreMismatch="off", publish="off", startNew="on")
             api_data = await ssllabs.analyze(host="devolo.de", from_cache=True)
             assert dataclasses.asdict(api_data) == request.cls.analyze
-            assert get.call_args.kwargs["startNew"] == "off"
+            get.assert_called_with(host="devolo.de", ignoreMismatch="off", publish="off", startNew="off")
 
     @pytest.mark.asyncio
     async def test_analyze_not_ready_yet(self, request, mocker):


### PR DESCRIPTION
Up to now we expected, that only fresh results are interesting when querying the ssllabs API. However, there seem to be usecases for cached results, too.

See: #32 