### PR TITLE
Add missing parameter for cached results

### DIFF
--- a/ssllabs/ssllabs.py
+++ b/ssllabs/ssllabs.py
@@ -71,6 +71,7 @@ class Ssllabs:
         host_object = await a.get(
             host=host,
             startNew="off" if from_cache else "on",
+            fromCache="on" if from_cache else "off",
             publish="on" if publish else "off",
             ignoreMismatch="on" if ignore_mismatch else "off",
             maxAge=max_age,

--- a/tests/test_ssllabs.py
+++ b/tests/test_ssllabs.py
@@ -43,10 +43,14 @@ class TestSsllabs:
             ssllabs = Ssllabs()
             api_data = await ssllabs.analyze(host="devolo.de")
             assert dataclasses.asdict(api_data) == request.cls.analyze
-            get.assert_called_with(host="devolo.de", ignoreMismatch="off", publish="off", startNew="on", fromCache="off", maxAge=None)
+            get.assert_called_with(
+                host="devolo.de", ignoreMismatch="off", publish="off", startNew="on", fromCache="off", maxAge=None
+            )
             api_data = await ssllabs.analyze(host="devolo.de", from_cache=True, max_age=1)
             assert dataclasses.asdict(api_data) == request.cls.analyze
-            get.assert_called_with(host="devolo.de", ignoreMismatch="off", publish="off", startNew="off", fromCache="on", maxAge=1)
+            get.assert_called_with(
+                host="devolo.de", ignoreMismatch="off", publish="off", startNew="off", fromCache="on", maxAge=1
+            )
 
     @pytest.mark.asyncio
     async def test_analyze_not_ready_yet(self, request, mocker):

--- a/tests/test_ssllabs.py
+++ b/tests/test_ssllabs.py
@@ -43,10 +43,10 @@ class TestSsllabs:
             ssllabs = Ssllabs()
             api_data = await ssllabs.analyze(host="devolo.de")
             assert dataclasses.asdict(api_data) == request.cls.analyze
-            get.assert_called_with(host="devolo.de", ignoreMismatch="off", publish="off", startNew="on", maxAge=None)
+            get.assert_called_with(host="devolo.de", ignoreMismatch="off", publish="off", startNew="on", fromCache="off", maxAge=None)
             api_data = await ssllabs.analyze(host="devolo.de", from_cache=True, max_age=1)
             assert dataclasses.asdict(api_data) == request.cls.analyze
-            get.assert_called_with(host="devolo.de", ignoreMismatch="off", publish="off", startNew="off", maxAge=1)
+            get.assert_called_with(host="devolo.de", ignoreMismatch="off", publish="off", startNew="off", fromCache="on", maxAge=1)
 
     @pytest.mark.asyncio
     async def test_analyze_not_ready_yet(self, request, mocker):


### PR DESCRIPTION
Setting startNew to off and maxAge will still trigger a new analysis. The parameter fromCache must be explicitly be set to on.