### PR TITLE
Run CI also on pull request

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 


### PR DESCRIPTION
Run CI not only on push but also on pull_request trigger. This allows the CI to run if the change was made on a fork.