### PR TITLE
Update versions in CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.0.0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.7.0
       with:
-        python-version: 3.8
+        python-version: "3.8"
     - name: Check formatting
       uses: pre-commit/action@v3.0.0
 
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.0.0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.7.0
       with:
-        python-version: 3.8
+        python-version: "3.8"
     - name: Lint with flake8
       run: |
         python -m pip install --upgrade pip
@@ -49,14 +49,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.0.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.7.0
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         check-latest: true
     - name: Install dependencies
       run: |

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0.0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.7.0
       with:
         python-version: "3.8"
     - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
--   repo: https://github.com/psf/black
-    rev: '23.1.0'
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: '23.9.1'
     hooks:
     - id: black
 -   repo: https://github.com/pycqa/isort

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    install_requires=["dacite", "httpx"],
+    install_requires=["importlib-metadata;python_version<'3.8'", "dacite", "httpx"],
     extras_require={
         "dev": [
             "pre-commit",

--- a/ssllabs/__init__.py
+++ b/ssllabs/__init__.py
@@ -1,12 +1,13 @@
-from pkg_resources import DistributionNotFound, get_distribution
+"""Qualys SSL Labs API in Python."""
+from importlib.metadata import PackageNotFoundError, version
 
 from .ssllabs import Ssllabs
 
 __license__ = "MIT"
 
 try:
-    __version__ = get_distribution(__package__).version
-except DistributionNotFound:
+    __version__ = version("ssllabs")
+except PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0"
 

--- a/ssllabs/__init__.py
+++ b/ssllabs/__init__.py
@@ -1,5 +1,8 @@
 """Qualys SSL Labs API in Python."""
-from importlib.metadata import PackageNotFoundError, version
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError, version  # type: ignore
 
 from .ssllabs import Ssllabs
 


### PR DESCRIPTION
Update action versions in CI and add Python 3.12 to the test matrix. Additionally, pkg_resources needs to be exchanged with importlib.metadata (and its backport for Python 3.7) because it was removed in Python 3.12.