### PR TITLE
Added option to include endpoint details

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.2
     - name: Set up Python
       uses: actions/setup-python@v5.1.0
       with:
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.2
     - name: Set up Python
       uses: actions/setup-python@v5.1.0
       with:
@@ -52,7 +52,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5.1.0
       with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v5.1.0
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: "3.8"
     - name: Check formatting
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v5.1.0
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: "3.8"
     - name: Lint with flake8
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v4.2.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.1.0
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4.1.7

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v5.1.0
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: "3.8"
     - name: Install dependencies

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.1.7
+    - uses: actions/checkout@v4.2.2
     - name: Set up Python
       uses: actions/setup-python@v5.1.0
       with:

--- a/ssllabs/ssllabs.py
+++ b/ssllabs/ssllabs.py
@@ -39,7 +39,6 @@ class Ssllabs:
         publish: bool = False,
         ignore_mismatch: bool = False,
         from_cache: bool = False,
-        include_details: bool = True,
         max_age: Optional[int] = None,
     ) -> HostData:
         """
@@ -49,7 +48,6 @@ class Ssllabs:
         :param publish: True if assessment results should be published on the public results boards
         :param ignore_mismatch: True if assessment shall proceed even when the server certificate doesn't match the hostname
         :param from_cache: True if cached results should be used instead of new assessments
-        :param include_details: True if endpoint details should be returned
         :param max_age: Maximum age cached data might have in hours
 
         See also: https://github.com/ssllabs/ssllabs-scan/blob/master/ssllabs-api-docs-v3.md#protocol-usage
@@ -76,14 +74,14 @@ class Ssllabs:
             fromCache="on" if from_cache else "off",
             publish="on" if publish else "off",
             ignoreMismatch="on" if ignore_mismatch else "off",
-            all="done" if include_details else "off",
+            all="done",
             maxAge=max_age,
         )
         self._semaphore.release()
         while host_object.status not in ["READY", "ERROR"]:
             self._logger.debug("Assessment of %s not ready yet.", host)
             await asyncio.sleep(10)
-            host_object = await a.get(host=host, all="done" if include_details else "off")
+            host_object = await a.get(host=host, all="done")
         return host_object
 
     async def info(self) -> InfoData:

--- a/ssllabs/ssllabs.py
+++ b/ssllabs/ssllabs.py
@@ -39,6 +39,7 @@ class Ssllabs:
         publish: bool = False,
         ignore_mismatch: bool = False,
         from_cache: bool = False,
+        include_details: bool = True,
         max_age: Optional[int] = None,
     ) -> HostData:
         """
@@ -48,6 +49,7 @@ class Ssllabs:
         :param publish: True if assessment results should be published on the public results boards
         :param ignore_mismatch: True if assessment shall proceed even when the server certificate doesn't match the hostname
         :param from_cache: True if cached results should be used instead of new assessments
+        :param include_details: True if endpoint details should be returned
         :param max_age: Maximum age cached data might have in hours
 
         See also: https://github.com/ssllabs/ssllabs-scan/blob/master/ssllabs-api-docs-v3.md#protocol-usage
@@ -74,13 +76,14 @@ class Ssllabs:
             fromCache="on" if from_cache else "off",
             publish="on" if publish else "off",
             ignoreMismatch="on" if ignore_mismatch else "off",
+            all="done" if include_details else "off",
             maxAge=max_age,
         )
         self._semaphore.release()
         while host_object.status not in ["READY", "ERROR"]:
             self._logger.debug("Assessment of %s not ready yet.", host)
             await asyncio.sleep(10)
-            host_object = await a.get(host=host, all="done")
+            host_object = await a.get(host=host, all="done" if include_details else "off")
         return host_object
 
     async def info(self) -> InfoData:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,14 +16,3 @@ def test_data_fixture(request):
         with file.open("r") as fh:
             test_data = json.load(fh)
             setattr(request.cls, filename, test_data)
-
-
-@pytest.fixture()
-def event_loop():
-    loop = asyncio.get_event_loop()
-    yield loop
-    to_cancel = asyncio.tasks.all_tasks(loop)
-    for task in to_cancel:
-        task.cancel()
-    loop.run_until_complete(asyncio.tasks.gather(*to_cancel, return_exceptions=True))
-    loop.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,6 +30,8 @@ class TestApi:
         httpx_mock.add_response(json=request.cls.info)
         r = await _Api()._call("")  # pylint: disable=protected-access
         assert r.json() == request.cls.info
+
+        httpx_mock.add_response(json=request.cls.info)
         client = AsyncClient()
         r = await _Api(client)._call("")  # pylint: disable=protected-access
         await client.aclose()

--- a/tests/test_ssllabs.py
+++ b/tests/test_ssllabs.py
@@ -44,12 +44,12 @@ class TestSsllabs:
             api_data = await ssllabs.analyze(host="devolo.de")
             assert dataclasses.asdict(api_data) == request.cls.analyze
             get.assert_called_with(
-                host="devolo.de", ignoreMismatch="off", publish="off", startNew="on", fromCache="off", maxAge=None
+                host="devolo.de", ignoreMismatch="off", publish="off", startNew="on", fromCache="off", maxAge=None, all="done"
             )
             api_data = await ssllabs.analyze(host="devolo.de", from_cache=True, max_age=1)
             assert dataclasses.asdict(api_data) == request.cls.analyze
             get.assert_called_with(
-                host="devolo.de", ignoreMismatch="off", publish="off", startNew="off", fromCache="on", maxAge=1
+                host="devolo.de", ignoreMismatch="off", publish="off", startNew="off", fromCache="on", maxAge=1, all="done"
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Allows for setting if full endpoint details are returned, and fixes a bug where endpoint details weren't returned when retrieving results from cache.